### PR TITLE
Fix Rounding on Evaluation Page

### DIFF
--- a/src/components/simulation/Evaluation/Evaluation.tsx
+++ b/src/components/simulation/Evaluation/Evaluation.tsx
@@ -55,8 +55,9 @@ const Evaluation: FC<propsType> = ({ propVals, setStage }) => {
 
         // balance criteria
         let sp = vals.balance / vals.income;
-        if (vals.balance < 0)
-          info.push({ show: vals.balance, positive: false });
+        if (vals.balance < 0) {
+          info.push({ show: '-$' + Math.abs(Number(vals.balance.toFixed(2))), positive: false });
+        }
         else if (sp < savingTarget)
           info.push({
             show: (sp * 100).toFixed(2) + '%',
@@ -64,7 +65,7 @@ const Evaluation: FC<propsType> = ({ propVals, setStage }) => {
             pMsg: 1,
           });
         else {
-          info.push({ show: vals.balance, positive: true, pMsg: 0 });
+          info.push({ show: '$' + vals.balance.toFixed(2), positive: true, pMsg: 0 });
         }
 
         // Rent criteria


### PR DESCRIPTION
This PR rounds the Total Savings (balance) criteria to two decimal places and appends a '$' to the number. This was updated for both positive and negative balances. The remaining criteria on the Evaluation page are already correctly rounded.

**Before**
<img width="800" alt="Screenshot 2024-10-20 at 8 09 38 PM" src="https://github.com/user-attachments/assets/e1afd61a-05e7-4e5c-988c-f534a38d90d2">

**After**
<img width="811" alt="Screenshot 2024-10-20 at 8 08 50 PM" src="https://github.com/user-attachments/assets/4d0162c1-b0ab-4e2e-a2d4-7e7ceb330c35">

**Before**
<img width="804" alt="Screenshot 2024-10-20 at 8 08 22 PM" src="https://github.com/user-attachments/assets/200a29cc-332a-44c5-a4e1-bb302dd950a5">

**After**
<img width="840" alt="Screenshot 2024-10-20 at 8 05 47 PM" src="https://github.com/user-attachments/assets/5b3c2719-b0cc-4b4d-901d-8ee5db55ef99">
