### PR TITLE
Adds tooltips to navbar

### DIFF
--- a/src/components/shared-components/Navbar.tsx
+++ b/src/components/shared-components/Navbar.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { IconGear, Home, Game, BackPack } from 'assets';
 import { NavLink } from 'react-router-dom';
+import './style.css';
 
 const Nav = styled.div`
   top: 0em;
@@ -37,22 +38,34 @@ const Navbar = ({
   return (
     <div>
       <Nav className={showNav ? 'show' : 'hide'}>
-        <NavLink activeStyle={active} className="nav-item txt-md" to="/">
-          <Icon src={Home} alt="" />
-        </NavLink>
-        <NavLink
-          activeStyle={active}
-          className="nav-item txt-md"
-          to="/simulation"
-        >
-          <Icon src={Game} alt="" />
-        </NavLink>
-        <NavLink activeStyle={active} className="nav-item txt-md" to="/classes">
-          <Icon src={BackPack} alt="" />
-        </NavLink>
-        <NavLink activeStyle={active} className="nav-item txt-md" to="/setting">
-          <Icon src={IconGear} alt="" />
-        </NavLink>
+        <div className="tooltip">
+          <NavLink activeStyle={active} className="nav-item txt-md" to="/">
+            <Icon src={Home} alt="" />
+          </NavLink>
+          <span className="tooltiptext">Home</span>
+        </div>
+        <div className="tooltip">
+          <NavLink
+            activeStyle={active}
+            className="nav-item txt-md"
+            to="/simulation"
+          >
+            <Icon src={Game} alt="" />
+          </NavLink>
+          <span className="tooltiptext">Simulation</span>
+        </div>
+        <div className="tooltip">
+          <NavLink activeStyle={active} className="nav-item txt-md" to="/classes">
+            <Icon src={BackPack} alt="" />
+          </NavLink>
+          <span className="tooltiptext">Classes</span>
+        </div>
+        <div className="tooltip">
+          <NavLink activeStyle={active} className="nav-item txt-md" to="/setting">
+            <Icon src={IconGear} alt="" />
+          </NavLink>
+          <span className="tooltiptext">Settings</span>
+        </div>
       </Nav>
     </div>
   );

--- a/src/components/shared-components/style.css
+++ b/src/components/shared-components/style.css
@@ -1,0 +1,26 @@
+.tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip .tooltiptext {
+  visibility: hidden;
+  width: 100px;
+  background-color: white;
+  color: black;
+  text-align: center;
+  border-radius: 6px;
+  padding: 5px 0;
+
+  /* Affects position of right tooltip */
+  top: 3px;
+  left: 105%;
+
+  /* Position the tooltip */
+  position: absolute;
+  z-index: 1;
+}
+
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+}


### PR DESCRIPTION
Adds simple tooltips to the navbar. Followed this [basic guide](https://www.w3schools.com/css/css_tooltip.asp). They only appear on hover.

Hovering over Settings:

<img width="223" alt="Screenshot 2024-11-01 at 14 16 22" src="https://github.com/user-attachments/assets/ac0fe796-9a2c-4df5-8b61-98fbddd45222">

Home:

<img width="188" alt="Screenshot 2024-11-01 at 14 16 06" src="https://github.com/user-attachments/assets/d42d17a9-8b52-43b0-89d8-85bc0041cb4b">

Simulation:

<img width="182" alt="Screenshot 2024-11-01 at 14 16 10" src="https://github.com/user-attachments/assets/6ec51aa9-60c1-4f35-93f4-642280fab152">

Classes:

<img width="202" alt="Screenshot 2024-11-01 at 14 16 13" src="https://github.com/user-attachments/assets/ec4a65dd-aecd-493d-8907-5471bc4b979c">

Settings:

<img width="206" alt="Screenshot 2024-11-01 at 14 16 16" src="https://github.com/user-attachments/assets/04ce4d84-4c24-4448-838f-e0be8a478fb9">

