### PR TITLE
Add instructions and tooltips to sim choices screen

### DIFF
--- a/src/components/booth/BoothSelect.tsx
+++ b/src/components/booth/BoothSelect.tsx
@@ -55,15 +55,18 @@ const BoothSelect = ({
     // }
   }
 
+  const tooltipTextComplete = "You can't revisit this category.";
+  const boothHasBeenVisited = (i: number) => visitedBooths.includes(i + 1)
+
   if (!boothsInfo) return null;
   else
     return (
       <Grid cols="1">
         {boothsInfo.map((info: any, i: number) => (
-          <div key={info.id}>
+          <div key={info.id} className='tooltip'>
             <button
               className={`customButton boothOption ${
-                visitedBooths.includes(i + 1) ? 'disabledBooth' : ''
+                boothHasBeenVisited(i) ? 'disabledBooth' : ''
               }`}
               onClick={(e) => {
                 if (!visitedBooths.includes(i + 1)) {
@@ -75,6 +78,10 @@ const BoothSelect = ({
               <img src={BoothIcons[i + 1]} className="boothIcon" />
               <p className={info.id}>{info.category}</p>
             </button>
+            { boothHasBeenVisited(i) && <span className='tooltiptext'>
+              {tooltipTextComplete}
+              </span>
+            }
           </div>
         ))}
       </Grid>

--- a/src/components/simulation/RunSimulation.tsx
+++ b/src/components/simulation/RunSimulation.tsx
@@ -217,6 +217,12 @@ const RunSimulation = (props: Props): JSX.Element => {
             )}
             {simStage === 'Booth-Selection' && (
               <div>
+                <h6 className="instructionsHeading">
+                  Click on each category to make choices about how to spend your money.
+                </h6>
+                <p className="instructionsParagraph">
+                  You can only visit each category once.
+                </p>
                 <UserInfo>
                   Remaining Income:{' '}
                   {myCareer.afterTaxMontlySalary

--- a/src/style/simulation.css
+++ b/src/style/simulation.css
@@ -180,3 +180,40 @@
   display: flex;
   flex-direction: column;
 }
+
+/* Simulation instructions */
+.instructionsHeading {
+  color: white;
+}
+.instructionsParagraph {
+  color: white;
+}
+
+/* Tooltips */
+
+.tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip .tooltiptext {
+  visibility: hidden;
+  width: 100px;
+  background-color: white;
+  color: black;
+  text-align: center;
+  border-radius: 6px;
+  padding: 5px 0;
+
+  /* Affects position of right tooltip */
+  top: 5px;
+  left: 105%;
+
+  /* Position the tooltip */
+  position: absolute;
+  z-index: 1;
+}
+
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+}


### PR DESCRIPTION
To clarify how to use the simulation choices screen, I added text at the top and also tooltips once a selection has already been made.

Similar to my recent PR that adds tooltips https://github.com/Dollars-and-Sense/Financial-App/pull/13. I didn't try to reuse the code because it's not exactly the same and because we may end up restructuring things later anyway. There are a lot of other improvements we could make in that regard.

Without hovering:
<img width="604" alt="Screenshot 2024-11-01 at 15 24 51" src="https://github.com/user-attachments/assets/0f5011f8-cad8-4131-a89a-a55ebf4416a6">

Hovering over the white one (and the disabled cursor shows at that time, though you can't see it in this screenshot):
<img width="611" alt="Screenshot 2024-11-01 at 15 24 56" src="https://github.com/user-attachments/assets/3e9bde85-d2b7-45d7-aaad-999678f05e80">

Before:

<img width="419" alt="Screenshot 2024-11-01 at 15 31 31" src="https://github.com/user-attachments/assets/26c60f1f-a4e1-48e0-a504-e446686424fe">

