### PR TITLE
Update Job Details Part 2

### DIFF
--- a/src/components/jobs/JobSummary.tsx
+++ b/src/components/jobs/JobSummary.tsx
@@ -45,7 +45,7 @@ const JobSummary = ({ career }: { career: career }): JSX.Element => {
   const edu = career.education;
   const position = career.position;
 
-  const netMonth = formatDollars(career.afterTaxMontlySalary);
+  const netMonth = formatDollars(career.afterTaxMonthlySalary);
 
   const vowel = new Set(['A', 'E', 'I', 'O', 'U']);
 

--- a/src/components/simulation/RunSimulation.tsx
+++ b/src/components/simulation/RunSimulation.tsx
@@ -140,20 +140,21 @@ const RunSimulation = (props: Props): JSX.Element => {
   const getJobDetail = (jobname: string, setJobInBackend: boolean = false) => {
     api
       .getJobDetail(jobname.replaceAll('/', '_')) // String needs to be fixed before sending to backend
-      .then((occupation: career) => {
+      .then((occupation) => {
         const { annual_salary, training, credit, ...other_attr } = occupation;
-        const y: number = annual_salary / 12; // Monthly salary
+        const fed_rate = other_attr.federal_tax_rate_mo || 0.15
+        const y: number = parseFloat((annual_salary / 12).toFixed(2)); // Monthly salary
         const career = {
           position: jobname,
-          monthlySalary: parseFloat(y.toFixed(2)),
+          monthlySalary: y,
           annual_salary,
           hourlyRate: annual_salary / 52 / 40,
-          federalTax: y * (other_attr?.federal_tax_rate_mo || 0.15),
-          socialSecurity: y * (other_attr?.social_security_rate_mo || 0.06),
-          medicare: y * (other_attr?.medicare_rate_mo || 0.014),
-          stateTax: y * (other_attr?.state_tax_rate_mo || 0.033),
+          federalTax: y * (other_attr.federal_tax_rate_mo || 0.15),
+          socialSecurity: y * (other_attr.social_security_rate_mo || 0.06),
+          medicare: y * (other_attr.medicare_rate_mo || 0.014),
+          stateTax: y * (other_attr.state_tax_rate_mo || 0.033),
           insurance: y * 0.035,
-          education: other_attr?.education || "Bachelor's",
+          education: other_attr.education || "Bachelor's",
           training,
           credit,
           afterTaxMonthlySalary: 0

--- a/src/components/simulation/RunSimulation.tsx
+++ b/src/components/simulation/RunSimulation.tsx
@@ -39,7 +39,7 @@ export interface career {
   medicare: number;
   stateTax: number;
   education: string;
-  afterTaxMontlySalary: number;
+  afterTaxMonthlySalary: number;
   training: number;
   credit: number;
   insurance: number;
@@ -55,7 +55,7 @@ const tempCareer = {
   position: 'Carpenter',
   socialSecurity: 155.68800000000002,
   stateTax: 85.62840000000001,
-  afterTaxMontlySalary: 1190.235648,
+  afterTaxMonthlySalary: 1190.235648,
   training: 0,
   credit: 0,
   insurance: 0,
@@ -99,7 +99,7 @@ const RunSimulation = (props: Props): JSX.Element => {
    * Update Salary after a career is selected
    */
   useEffect(() => {
-    setCurrentBalance(myCareer.afterTaxMontlySalary);
+    setCurrentBalance(myCareer.afterTaxMonthlySalary);
   }, [myCareer]);
 
   useEffect(() => {
@@ -141,24 +141,33 @@ const RunSimulation = (props: Props): JSX.Element => {
     api
       .getJobDetail(jobname.replaceAll('/', '_')) // String needs to be fixed before sending to backend
       .then((occupation: career) => {
-        let y: number = occupation.annual_salary / 12; // Monthly salary
-        let { training, credit } = occupation;
-        setMyCareer({
+        const { annual_salary, training, credit, ...other_attr } = occupation;
+        const y: number = annual_salary / 12; // Monthly salary
+        const career = {
           position: jobname,
           monthlySalary: parseFloat(y.toFixed(2)),
-          annual_salary: occupation.annual_salary,
-          hourlyRate: y / 160,
-          federalTax: y * 0.15,
-          socialSecurity: y * 0.06,
-          medicare: y * 0.014,
-          stateTax: y * 0.033,
+          annual_salary,
+          hourlyRate: annual_salary / 52 / 40,
+          federalTax: y * (other_attr?.federal_tax_rate_mo || 0.15),
+          socialSecurity: y * (other_attr?.social_security_rate_mo || 0.06),
+          medicare: y * (other_attr?.medicare_rate_mo || 0.014),
+          stateTax: y * (other_attr?.state_tax_rate_mo || 0.033),
           insurance: y * 0.035,
-          education: "Bachelor's",
+          education: other_attr?.education || "Bachelor's",
           training,
           credit,
-          afterTaxMontlySalary:
-            y - y * (0.15 + 0.06 + 0.014 + 0.033 + 0.035) - training - credit,
-        });
+          afterTaxMonthlySalary: 0
+        };
+        career.afterTaxMonthlySalary =
+          career.monthlySalary -
+          career.federalTax -
+          career.socialSecurity -
+          career.medicare -
+          career.stateTax -
+          career.insurance -
+          career.training -
+          career.credit;
+        setMyCareer(career);
 
         setSimStage('Job-Selected'); // Change the state of "RunSimulation" component when donw
         if (setJobInBackend)
@@ -225,7 +234,7 @@ const RunSimulation = (props: Props): JSX.Element => {
                 </p>
                 <UserInfo>
                   Remaining Monthly Income:{' '}
-                  ${myCareer.afterTaxMontlySalary
+                  ${myCareer.afterTaxMonthlySalary
                     ? currentBalance.toFixed(2)
                     : ''}
                 </UserInfo>

--- a/src/components/simulation/RunSimulation.tsx
+++ b/src/components/simulation/RunSimulation.tsx
@@ -142,7 +142,6 @@ const RunSimulation = (props: Props): JSX.Element => {
       .getJobDetail(jobname.replaceAll('/', '_')) // String needs to be fixed before sending to backend
       .then((occupation) => {
         const { annual_salary, training, credit, ...other_attr } = occupation;
-        const fed_rate = other_attr.federal_tax_rate_mo || 0.15
         const y: number = parseFloat((annual_salary / 12).toFixed(2)); // Monthly salary
         const career = {
           position: jobname,


### PR DESCRIPTION
- Update `RunSimulation` to handle updated job detail in response
  - Fixes incorrect data issue due to using default values on FE for all roles (for example, tax rate would vary by job)
  - As updates from Kim Lowery's 2024 job details spreadsheet were for 11 jobs only, change in `getJobDetail` will use default values for the other jobs without the additional attributes
- PR for API update merged & validated locally: https://github.com/Dollars-and-Sense/finapp-API/pull/6
- Fix typo with `afterTaxMontlySalary`, Typescript error (occupation != career interface)

### Validation Locally:

- Updated Job Detail

![Accountant-Auditor_v2](https://github.com/user-attachments/assets/fcbd73c4-b1b6-4d5a-a2ad-4889fad668a1)
![AdminAsst_v2](https://github.com/user-attachments/assets/035971dd-c9d0-4584-9b06-bfab53601897)

- Non-Updated Job Detail (BAU)

![Housekeeper](https://github.com/user-attachments/assets/e1c30816-e740-4955-a221-bd5b7b717d66)

- API Change

![Accountant-Auditor_api_update](https://github.com/user-attachments/assets/fae1d42b-6d86-41d8-b99f-329968ffe1c3)
